### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A MCP (Model Context Protocol) server that provides get, send Gmails without local credential or token setup.
 
+<a href="https://glama.ai/mcp/servers/@baryhuang/mcp-headless-gmail">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@baryhuang/mcp-headless-gmail/badge" alt="Headless Gmail Server MCP server" />
+</a>
+
 ## Why MCP Headless Gmail Server?
 ### Critical Advantages
 - **Headless & Remote Operation**: Unlike other MCP Gmail solutions that require running outside of docker and local file access, this server can run completely headless in remote environments with no browser no local file access.
@@ -234,4 +238,4 @@ This server requires direct access to your Google API credentials. Always keep y
 
 ## License
 
-See the LICENSE file for details. 
+See the LICENSE file for details.


### PR DESCRIPTION
This PR adds a badge for the [MCP Headless Gmail Server](https://glama.ai/mcp/servers/@baryhuang/mcp-headless-gmail) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@baryhuang/mcp-headless-gmail">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@baryhuang/mcp-headless-gmail/badge" alt="Headless Gmail Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.